### PR TITLE
first pass of transactionsAPI, fixed export statements in requestAPI

### DIFF
--- a/APIs/requestAPI/controllers/requestController.js
+++ b/APIs/requestAPI/controllers/requestController.js
@@ -86,7 +86,6 @@ requestController.getRequestsByBorrower = async (req, res, next) => {
   }
 };
 
-// add a new transaction to the database
 // update request status in database
 requestController.resolveRequest = async (req, res, next) => {
   const { requestId, status } = req.body;
@@ -110,3 +109,5 @@ requestController.resolveRequest = async (req, res, next) => {
     });
   }
 };
+
+module.exports = requestController;

--- a/APIs/requestAPI/routes/request.js
+++ b/APIs/requestAPI/routes/request.js
@@ -1,19 +1,23 @@
 const express = require('express');
 const requestController = require('../controllers/requestController');
-const router = express.Router();
+const requestRouter = express.Router();
 
 // request to borrow a tool
-router.post('/', requestController.requestToolById, (req, res) => {
+requestRouter.post('/', requestController.requestToolById, (req, res) => {
   res.status(200).json(res.locals);
 });
 
 // retrieve requests by owner id
-router.get('/:owner_id', requestController.getRequestsByOwner, (req, res) => {
-  res.status(200).json(res.locals);
-});
+requestRouter.get(
+  '/:owner_id',
+  requestController.getRequestsByOwner,
+  (req, res) => {
+    res.status(200).json(res.locals);
+  }
+);
 
 // retrieve requests by borrower id
-router.get(
+requestRouter.get(
   '/:borrower_id',
   requestController.getRequestsByBorrower,
   (req, res) => {
@@ -22,8 +26,8 @@ router.get(
 );
 
 // approve or reject a request for your tool
-router.put('/', requestController.resolveRequest, (req, res) => {
+requestRouter.put('/', requestController.resolveRequest, (req, res) => {
   res.status(200).json(res.locals);
 });
 
-module.exports = router;
+module.exports = requestRouter;

--- a/APIs/transactionsAPI/controllers/transactionsController.js
+++ b/APIs/transactionsAPI/controllers/transactionsController.js
@@ -1,0 +1,146 @@
+const db = require('../models/database');
+
+const transactionController = {};
+
+// retrieve all transactions for tools owned by a particular user
+transactionsController.getTransactionsByOwner = async (req, res, next) => {
+  const ownerId = req.params.owner_id;
+
+  try {
+    const getTransactionsByOwnerQuery = `
+            SELECT
+            transactions._id as requestId
+            transactions.borrower_id as borrowerId
+            transactions.tool_id as toolId
+            transactions.created_at as createdAt
+            transactions.completed at completed
+            FROM transactions
+            WHERE transactions.owner_id = $1`;
+
+    const response = await db.query(getTransactionsByOwnerQuery, [ownerId]);
+    res.locals.transactions = response.rows;
+
+    return next();
+  } catch (error) {
+    return next({
+      log: `transactionsController.getTransactionsByOwner: ERROR: ${error}`,
+      message: {
+        err: 'transactionsController.getTransactionsByOwner: ERROR: Check server logs for details.'
+      }
+    });
+  }
+};
+
+// retrieve all transactions for tools borrowed by a particular user
+transactionsController.getTransactionsByBorrower = async (req, res, next) => {
+  const borrowerId = req.params.borrower_id;
+
+  try {
+    const getTransactionsByBorrowerQuery = `
+            SELECT
+            transactions._id as requestId
+            transactions.owner_id as ownerId
+            transactions.tool_id as toolId
+            transactions.created_at as createdAt
+            transactions.completed at completed
+            FROM transactions
+            WHERE transactions.borrower_id = $1`;
+
+    const response = await db.query(getTransactionsByBorrowerQuery, [
+      borrowerId
+    ]);
+    res.locals.transactions = response.rows;
+
+    return next();
+  } catch (error) {
+    return next({
+      log: `transactionsController.getTransactionsByBorrower: ERROR: ${error}`,
+      message: {
+        err: 'transactionsController.getTransactionsByBorrower: ERROR: Check server logs for details.'
+      }
+    });
+  }
+};
+
+// retrieve all transactions for a particular tool
+transactionsController.getTransactionsByTool = async (req, res, next) => {
+  const toolId = req.params.tool_id;
+
+  try {
+    const getTransactionsByToolQuery = `
+              SELECT
+              transactions._id as requestId
+              transactions.owner_id as ownerId
+              transactions.borrower_id as borrowerId
+              transactions.created_at as createdAt
+              transactions.completed at completed
+              FROM transactions
+              WHERE transactions.tool_id = $1`;
+
+    const response = await db.query(getTransactionsByToolQuery, [toolId]);
+    res.locals.transactions = response.rows;
+
+    return next();
+  } catch (error) {
+    return next({
+      log: `transactionsController.getTransactionsByTool: ERROR: ${error}`,
+      message: {
+        err: 'transactionsController.getTransactionsByTool: ERROR: Check server logs for details.'
+      }
+    });
+  }
+};
+
+// add a transaction when a request is approved
+transactionController.openTransaction = async (req, res, next) => {
+  const { borrower_id, owner_id, tool_id } = req.body;
+
+  try {
+    const openTransactionQuery = `
+        INSERT INTO transactions (borrower_id, owner_id, tool_id)
+        VALUES ($1, $2, $3)
+        RETURNING *`;
+
+    const response = await db.query(openTransactionQuery, [
+      borrower_id,
+      owner_id,
+      tool_id
+    ]);
+    res.locals.transaction = response.rows;
+
+    return next();
+  } catch (error) {
+    return next({
+      log: `transactionsController.openTransaction: ERROR: ${error}`,
+      message: {
+        err: 'transactionsController.openTransaction: ERROR: Check server logs for details.'
+      }
+    });
+  }
+};
+
+// update transaction status when item is returned
+transactionController.closeTransaction = async (req, res, next) => {
+  const { transactionId } = req.body;
+
+  try {
+    const closeTransactionQuery = `
+            UPDATE transactions
+            SET completed = TRUE
+            WHERE _id = $1`;
+
+    const response = await db.query(closeTransactionQuery, [transactionId]);
+    res.locals.request = response.rows;
+
+    return next();
+  } catch (error) {
+    return next({
+      log: `transactionController.closeTransaction: ERROR: ${error}`,
+      message: {
+        err: 'transactionController.closeTransaction: ERROR: Check server logs for details.'
+      }
+    });
+  }
+};
+
+module.exports = transactionsController;

--- a/APIs/transactionsAPI/routes/transactions.js
+++ b/APIs/transactionsAPI/routes/transactions.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const transactionsController = require('../controllers/transactionsController');
+const transactionsRouter = express.Router();
+
+// retrieve all transactions for tools owned by a particular user
+transactionsRouter.get(
+  '/:owner_id',
+  transactionsController.getTransactionsByOwner,
+  (req, res) => {
+    res.status(200).json(res.locals);
+  }
+);
+
+// retrieve all transactions for tools borrowed by a particular user
+transactionsRouter.get(
+  '/:borrower_id',
+  transactionsController.getTransactionsByBorrower,
+  (req, res) => {
+    res.status(200).json(res.locals);
+  }
+);
+
+// retrieve all transactions for a particular tool
+transactionsRouter.get(
+  '/:tool_id',
+  transactionsController.getTransactionsByTool,
+  (req, res) => {
+    res.status(200).json(res.locals);
+  }
+);
+
+// add a transaction when a request is approved
+transactionsRouter.post(
+  '/',
+  transactionsController.openTransaction,
+  (req, res) => {
+    res.status(200).json(res.locals);
+  }
+);
+
+// update transaction status when item is returned
+transactionsRouter.put(
+  '/',
+  transactionsController.closeTransaction,
+  (req, res) => {
+    res.status(200).json(res.locals);
+  }
+);
+
+module.exports = transactionsRouter;

--- a/APIs/transactionsAPI/server.js
+++ b/APIs/transactionsAPI/server.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const path = require('path');
+const transactionsRouter = require('./routes/transactions');
+
+const app = express();
+const PORT = 3003;
+
+/*
+1. app.use(express.json()) is used to parse JSON data sent by the client to the server.
+2. app.use(express.urlencoded({ extended: true })) is used to parse the form data sent by the client to the server.
+3. app.use(cookieParser()) is used to parse cookies sent by the client to the server.
+*/
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
+
+// Routers
+app.use('/transaction', transactionsRouter);
+
+// Error Handling
+
+app.use('*', (req, res) => res.status(404).send('Route not found'));
+
+app.use((err, req, res, next) => {
+  const defaultErr = {
+    log: 'Express error handler caught unknown middleware error',
+    status: 500,
+    message: { err: 'An error occurred in tools server' }
+  };
+  const errorObj = Object.assign({}, defaultErr, err);
+  console.log(errorObj.log);
+  return res.status(errorObj.status).json(errorObj.message);
+});
+
+app.listen(PORT, () =>
+  console.log(`Transaction server is listening on port ${PORT}...`)
+);


### PR DESCRIPTION
First pass of the transactions API. Added the following routes:

- GET/:owner_id (get all transactions for tools owned by a particular user)
- GET/:borrower_id (get all transactions for tools borrowed by a particular user)
- GET/:tool_id (get all transactions for a particular tool)
- POST / (add a  new transaction)
- PUT /  (update transaction "completed" column to TRUE when item is returned)

Corrected some syntax errors and clarified variable names in the requestAPI.